### PR TITLE
Remove visible setting to prevent empty mainpage on SFOS4

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -384,7 +384,6 @@ Page {
 
     Page {
         id: mainPage
-        visible: false
 
         SilicaListView {
             id: listView


### PR DESCRIPTION
I do not notice any regression/change when installing the modified version in SFOS3, and it fixes the empty screen in SFOS4.

An official SFOS release of a new version is usually 1 or 2 weeks after the early release. But as it should work fine in both SFOS3 and SFOS4 that seems not relevant.